### PR TITLE
Return JSON from login and fix dashboard redirect

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -208,7 +208,7 @@
                                 if (data.success) {
                                     message.innerHTML = '<div class="success-message">ACCESS GRANTED - LOADING PFAFF TERMINAL...</div>';
                                     setTimeout(function() {
-                                        window.location.href = '/dashboard';
+                                        window.location.href = '/dashboard.html';
                                     }, 1500);
                                 } else {
                                     message.innerHTML = '<div class="error-message">' + (data.error || 'ACCESS DENIED') + '</div>';
@@ -282,7 +282,7 @@
                         try {
                             var data = JSON.parse(authCheck.responseText);
                             if (data.authenticated) {
-                                window.location.href = '/dashboard';
+                                window.location.href = '/dashboard.html';
                             }
                         } catch (e) {
                             // Ignore auth check errors

--- a/public/login.js
+++ b/public/login.js
@@ -54,7 +54,7 @@ async function checkAuthStatus() {
             const data = await response.json();
             if (data.authenticated) {
                 console.log('Already authenticated, redirecting...');
-                window.location.href = '/dashboard';
+                window.location.href = '/dashboard.html';
                 return;
             }
         }
@@ -112,7 +112,7 @@ async function handleLogin() {
             // Redirect after brief delay
             setTimeout(() => {
                 console.log('Redirecting to dashboard...');
-                window.location.href = '/dashboard';
+                window.location.href = '/dashboard.html';
             }, 1500);
         } else {
             console.log('Login failed:', data.error);

--- a/server.js
+++ b/server.js
@@ -107,19 +107,30 @@ app.get('/auth/login', (req, res) => {
 app.post('/auth/login', async (req, res) => {
   try {
     const { username, password } = req.body || {};
-    if (!ADMIN_PASSWORD_HASH) return res.status(500).send('Server not configured (ADMIN_PASSWORD_HASH missing).');
+    if (!ADMIN_PASSWORD_HASH) {
+      return res.status(500).json({ success: false, error: 'Server not configured (ADMIN_PASSWORD_HASH missing).' });
+    }
 
-    if (clean(username) !== ADMIN_USERNAME) return res.status(401).send('Invalid credentials.');
+    if (clean(username) !== ADMIN_USERNAME) {
+      return res.status(401).json({ success: false, error: 'Invalid credentials.' });
+    }
     const ok = await bcrypt.compare(password || '', ADMIN_PASSWORD_HASH);
-    if (!ok) return res.status(401).send('Invalid credentials.');
+    if (!ok) {
+      return res.status(401).json({ success: false, error: 'Invalid credentials.' });
+    }
 
     req.session.authenticated = true;
     req.session.user = { username: ADMIN_USERNAME };
-    res.redirect('/');
+    return res.json({ success: true });
   } catch (err) {
     console.error('Login error:', err);
-    res.status(500).send('Login failed.');
+    res.status(500).json({ success: false, error: 'Login failed.' });
   }
+});
+
+app.get('/auth/status', (req, res) => {
+  const authenticated = !!(req.session && req.session.authenticated);
+  res.json({ authenticated });
 });
 
 app.post('/auth/logout', (req, res) => {


### PR DESCRIPTION
## Summary
- send structured JSON responses for `/auth/login`
- add `/auth/status` endpoint to check session state
- point login page/scripts to `dashboard.html`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a528d1e108320adbd6a93f3e2db98