### PR TITLE
Require login for dashboard

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -208,7 +208,7 @@
                                 if (data.success) {
                                     message.innerHTML = '<div class="success-message">ACCESS GRANTED - LOADING PFAFF TERMINAL...</div>';
                                     setTimeout(function() {
-                                        window.location.href = '/dashboard.html';
+                                        window.location.href = '/';
                                     }, 1500);
                                 } else {
                                     message.innerHTML = '<div class="error-message">' + (data.error || 'ACCESS DENIED') + '</div>';
@@ -282,7 +282,7 @@
                         try {
                             var data = JSON.parse(authCheck.responseText);
                             if (data.authenticated) {
-                                window.location.href = '/dashboard.html';
+                                window.location.href = '/';
                             }
                         } catch (e) {
                             // Ignore auth check errors

--- a/public/login.js
+++ b/public/login.js
@@ -54,7 +54,7 @@ async function checkAuthStatus() {
             const data = await response.json();
             if (data.authenticated) {
                 console.log('Already authenticated, redirecting...');
-                window.location.href = '/dashboard.html';
+                window.location.href = '/';
                 return;
             }
         }
@@ -112,7 +112,7 @@ async function handleLogin() {
             // Redirect after brief delay
             setTimeout(() => {
                 console.log('Redirecting to dashboard...');
-                window.location.href = '/dashboard.html';
+                window.location.href = '/';
             }, 1500);
         } else {
             console.log('Login failed:', data.error);

--- a/server.js
+++ b/server.js
@@ -45,7 +45,10 @@ app.use(session({
   },
 }));
 
-// Static assets (expects public/index.html and public/login.html)
+// Protect dashboard page but allow login assets
+app.use('/dashboard.html', requireAuth);
+
+// Static assets (expects public/dashboard.html and public/login.html)
 app.use(express.static(path.join(__dirname, 'public')));
 
 /* ---------------------------
@@ -141,8 +144,8 @@ app.post('/auth/logout', (req, res) => {
    App shell
 --------------------------- */
 app.get('/', requireAuth, (req, res) => {
-  const indexPath = path.join(__dirname, 'public', 'index.html');
-  res.sendFile(indexPath, (err) => {
+  const dashPath = path.join(__dirname, 'public', 'dashboard.html');
+  res.sendFile(dashPath, (err) => {
     if (err) res.status(200).send('<h1>PFAFF Terminal</h1><p>Logged in.</p>');
   });
 });


### PR DESCRIPTION
## Summary
- Protect dashboard.html with authentication middleware
- Serve dashboard.html at root path
- Redirect login page to dashboard root after authentication

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5b4e7f408320a05c283f2a2f0e91