### PR TITLE
Add Tiingo websocket support

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -112,6 +112,13 @@
                             <div class="loading">LOADING CRYPTO DATA</div>
                         </div>
                     </div>
+
+                    <div class="watchlist-section" style="margin-top: 15px;">
+                        <div class="section-title" style="color: #ffb700; font-size: 0.8rem; border-bottom: 1px solid #333; padding-bottom: 2px; margin-bottom: 4px;">FOREX</div>
+                        <div id="forexList">
+                            <div class="loading">LOADING FOREX DATA</div>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- expose Tiingo token via authenticated endpoint for websocket connections
- connect dashboard to Tiingo IEX websocket and stream live price updates
- track watchlist data client-side for real-time quote refreshes

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a5ce0f9988320bcde90640aca50e5