### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -208,7 +208,8 @@
                                 if (data.success) {
                                     message.innerHTML = '<div class="success-message">ACCESS GRANTED - LOADING PFAFF TERMINAL...</div>';
                                     setTimeout(function() {
-                                        window.location.href = '/';
+                                        // Redirect directly to the dashboard after successful auth
+                                        window.location.href = '/dashboard.html';
                                     }, 1500);
                                 } else {
                                     message.innerHTML = '<div class="error-message">' + (data.error || 'ACCESS DENIED') + '</div>';
@@ -282,7 +283,7 @@
                         try {
                             var data = JSON.parse(authCheck.responseText);
                             if (data.authenticated) {
-                                window.location.href = '/';
+                                window.location.href = '/dashboard.html';
                             }
                         } catch (e) {
                             // Ignore auth check errors

--- a/public/login.js
+++ b/public/login.js
@@ -54,7 +54,7 @@ async function checkAuthStatus() {
             const data = await response.json();
             if (data.authenticated) {
                 console.log('Already authenticated, redirecting...');
-                window.location.href = '/';
+                window.location.href = '/dashboard.html';
                 return;
             }
         }
@@ -112,7 +112,7 @@ async function handleLogin() {
             // Redirect after brief delay
             setTimeout(() => {
                 console.log('Redirecting to dashboard...');
-                window.location.href = '/';
+                window.location.href = '/dashboard.html';
             }, 1500);
         } else {
             console.log('Login failed:', data.error);


### PR DESCRIPTION
## Summary
- Redirect users to `/dashboard.html` after successful login
- Ensure already-authenticated users are taken directly to the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a62ebadbc8320a3f05e577ece1b79