### PR TITLE
fix fundamentals endpoint path

### DIFF
--- a/server.js
+++ b/server.js
@@ -283,7 +283,7 @@ app.get('/api/tiingo/crypto/prices', async (req, res) => {
 });
 
 // Fundamental definitions
-app.get('/api/tiingo/fundamentals/definitions', async (_req, res) => {
+app.get('/api/fundamentals/definitions', async (_req, res) => {
   try {
     const r = await tiingo.get('/tiingo/fundamentals/definitions');
     res.json(r.data);


### PR DESCRIPTION
## Summary
- align server fundamentals route with frontend fetch path

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a7a32c6648320a1a0805449372947